### PR TITLE
remove x-ms-client-flatten for ServiceResource

### DIFF
--- a/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabricManagedClusters/preview/2021-01-01-preview/managedapplication.json
+++ b/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabricManagedClusters/preview/2021-01-01-preview/managedapplication.json
@@ -2162,7 +2162,6 @@
       "description": "The service resource.",
       "properties": {
         "properties": {
-          "x-ms-client-flatten": true,
           "$ref": "#/definitions/ServiceResourceProperties"
         }
       },


### PR DESCRIPTION
remove x-ms-client-flatten for ServiceResource so that we can pass stateful or stateless properties in sdk